### PR TITLE
Replace email with link in maintainers

### DIFF
--- a/resources/falco/apache.yaml
+++ b/resources/falco/apache.yaml
@@ -52,9 +52,9 @@ keywords:
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/d/db/Apache_HTTP_server_logo_%282016%29.svg/300px-Apache_HTTP_server_logo_%282016%29.svg.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: apache_consider_syscalls

--- a/resources/falco/consul.yaml
+++ b/resources/falco/consul.yaml
@@ -77,9 +77,9 @@ keywords:
 icon: https://s3.amazonaws.com/hashicorp-marketing-web-assets/brand/Consul_PrimaryLogo_FullColor.BkqqyRBpl.svg
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: consul_consider_syscalls

--- a/resources/falco/cve/2019-14287.yaml
+++ b/resources/falco/cve/2019-14287.yaml
@@ -22,7 +22,7 @@ keywords:
 icon: https://cve.mitre.org/images/cvebanner.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
 rules:
   - raw: |
       - rule: Sudo Potential bypass of Runas user restrictions (CVE-2019-14287)

--- a/resources/falco/elasticsearch.yaml
+++ b/resources/falco/elasticsearch.yaml
@@ -83,9 +83,9 @@ keywords:
 icon: https://static-www.elastic.co/v3/assets/bltefdd0b53724fa2ce/blt05047fdbe3b9c333/5c11ec1f3312ce2e785d9c30/logo-elastic-elasticsearch-lt.svg
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: elasticsearch_consider_syscalls

--- a/resources/falco/etcd.yaml
+++ b/resources/falco/etcd.yaml
@@ -70,9 +70,9 @@ keywords:
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/etcd/horizontal/color/etcd-horizontal-color.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: etcd_consider_syscalls

--- a/resources/falco/fluentd.yaml
+++ b/resources/falco/fluentd.yaml
@@ -49,9 +49,9 @@ keywords:
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: fluentd_consider_syscalls

--- a/resources/falco/haproxy.yaml
+++ b/resources/falco/haproxy.yaml
@@ -55,9 +55,9 @@ keywords:
 icon: https://www.cncf.io/wp-content/uploads/2018/04/HAProxy-logo.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: haproxy_consider_syscalls

--- a/resources/falco/mongo.yaml
+++ b/resources/falco/mongo.yaml
@@ -65,9 +65,9 @@ keywords:
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/45/MongoDB-Logo.svg/2560px-MongoDB-Logo.svg.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: mongo_consider_syscalls

--- a/resources/falco/nginx.yaml
+++ b/resources/falco/nginx.yaml
@@ -79,9 +79,9 @@ keywords:
 icon: https://www.nginx.com/wp-content/themes/nginx-theme/assets/img/logo.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: nginx_consider_syscalls

--- a/resources/falco/postgres.yaml
+++ b/resources/falco/postgres.yaml
@@ -63,9 +63,9 @@ keywords:
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Postgresql_elephant.svg/540px-Postgresql_elephant.svg.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: postgres_consider_syscalls

--- a/resources/falco/redis.yaml
+++ b/resources/falco/redis.yaml
@@ -51,9 +51,9 @@ keywords:
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/2880px-Redis_Logo.svg.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: redis_consider_syscalls

--- a/resources/falco/rook.yaml
+++ b/resources/falco/rook.yaml
@@ -72,9 +72,9 @@ keywords:
 icon: https://www.pngfind.com/pngs/m/581-5811204_rook-kubernetes-logo-hd-png-download.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: rook_consider_syscalls

--- a/resources/falco/traefik.yaml
+++ b/resources/falco/traefik.yaml
@@ -34,9 +34,9 @@ keywords:
 icon: https://d33wubrfki0l68.cloudfront.net/1b8ea408142c253bb8e16596218e4e328d019c58/862c3/assets/img/traefik.logo.bright@3x.svg
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: traefik_consider_syscalls


### PR DESCRIPTION
Maybe a maintainer doesn't want to publish it's e-mail, this PR replaces the e-mail with a generic link from the maintainer structure.