### PR TITLE
Fix resources with broken vendor

### DIFF
--- a/resources/falco/fluentd.yaml
+++ b/resources/falco/fluentd.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 kind: FalcoRules
-vendor: FluentD
+vendor: Treasure Data
 name: FluentD
 shortDescription: Falco rules for securing FluentD
 description: |

--- a/resources/falco/redis.yaml
+++ b/resources/falco/redis.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 kind: FalcoRules
-vendor: Redis
+vendor: Redis Labs
 name: Redis
 shortDescription: Falco rules for securing Redis
 description: |


### PR DESCRIPTION
Some of the resources had incorrect vendor and therefore if someone clicked in the frontend, the backend answers correctly that the required vendor doesn't exist.
This PR fixes the vendors with their correct name.